### PR TITLE
エラー解決用プルリクエスト

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,7 @@ lock '3.11.0'
 # set :application, 'freemarket_sample_53a'
 
 # どのリポジトリからアプリをpullするかを指定する
+# 自分のリポジトリに修正
 set :repo_url,  'git@github.com:mshr-Hub/freemarket_sample_53a.git'
 
 # バージョンが変わっても共通で参照するディレクトリを指定

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,7 +1,9 @@
+# 自分のec2インスタンスに紐付けたElasticIPに変更
 server '52.69.189.4', user: 'ec2-user', roles: %w{app db web}
 
 set :rails_env, "production"
 set :unicorn_rack_env, "production"
+# キーの名前はそのまま
 set :application, 'freemarket_sample_53a'
 set :ssh_options, auth_methods: ['publickey'],
                   keys: ['~/.ssh/freemarket_sample_53a.pem']


### PR DESCRIPTION
### 自動デプロイ時のエラー内容
```
00:21 unicorn:stop
      cleaning up dead unicorn pid...
      01 rm /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid
    ✔ 01 ec2-user@52.69.189.4 0.093s
00:21 unicorn:start
      01 $HOME/.rbenv/bin/rbenv exec bundle exec unicorn -c /var/www/freemarket_sample_53a/current/config/unicorn.rb -E production -D 
      01 master failed to start, check stderr log for details
#<Thread:0x00007ff70ad12820@/Users/mac.mas6/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sshkit-1.20.0/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	1: from /Users/mac.mas6/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sshkit-1.20.0/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
/Users/mac.mas6/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sshkit-1.20.0/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': Exception while executing as ec2-user@52.69.189.4: bundle exit status: 1 (SSHKit::Runner::ExecuteError)
bundle stdout: Nothing written
bundle stderr: master failed to start, check stderr log for details
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as ec2-user@52.69.189.4: bundle exit status: 1
bundle stdout: Nothing written
bundle stderr: master failed to start, check stderr log for details


Caused by:
SSHKit::Command::Failed: bundle exit status: 1
bundle stdout: Nothing written
bundle stderr: master failed to start, check stderr log for details

Tasks: TOP => unicorn:start
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as ec2-user@52.69.189.4: bundle exit status: 1
bundle stdout: Nothing written
bundle stderr: master failed to start, check stderr log for details


** DEPLOY FAILED
** Refer to log/capistrano.log for details. Here are the last 20 lines:


 DEBUG [1739e756] Running [ -e /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid ] as ec2-user@52.69.189.4

 DEBUG [1739e756] Command: [ -e /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid ]

 DEBUG [1739e756] Finished in 0.090 seconds with exit status 0 (successful).

 DEBUG [598c37ca] Running kill -0 `cat /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid` as ec2-user@52.69.189.4

 DEBUG [598c37ca] Command: kill -0 `cat /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid`

 DEBUG [598c37ca] 	bash: 0 行: kill: (8488) - そのようなプロセスはありません

 DEBUG [598c37ca] Finished in 0.089 seconds with exit status 1 (failed).

  INFO cleaning up dead unicorn pid...

  INFO [010a9714] Running /usr/bin/env rm /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid as ec2-user@52.69.189.4

 DEBUG [010a9714] Command: cd /var/www/freemarket_sample_53a/current && ( export RBENV_ROOT="$HOME/.rbenv" RBENV_VERSION="2.5.1" ; /usr/bin/env rm /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid )

  INFO [010a9714] Finished in 0.093 seconds with exit status 0 (successful).

 DEBUG [16a4f5e7] Running if test ! -d /var/www/freemarket_sample_53a/current; then echo "Directory does not exist '/var/www/freemarket_sample_53a/current'" 1>&2; false; fi as ec2-user@52.69.189.4

 DEBUG [16a4f5e7] Command: if test ! -d /var/www/freemarket_sample_53a/current; then echo "Directory does not exist '/var/www/freemarket_sample_53a/current'" 1>&2; false; fi

 DEBUG [16a4f5e7] Finished in 0.088 seconds with exit status 0 (successful).

 DEBUG [aa31fc65] Running [ -e /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid ] && kill -0 `cat /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid` as ec2-user@52.69.189.4

 DEBUG [aa31fc65] Command: [ -e /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid ] && kill -0 `cat /var/www/freemarket_sample_53a/shared/tmp/pids/unicorn.pid`

 DEBUG [aa31fc65] Finished in 0.087 seconds with exit status 1 (failed).

  INFO [f1721628] Running $HOME/.rbenv/bin/rbenv exec bundle exec unicorn -c /var/www/freemarket_sample_53a/current/config/unicorn.rb -E production -D  as ec2-user@52.69.189.4

 DEBUG [f1721628] Command: cd /var/www/freemarket_sample_53a/current && ( export RBENV_ROOT="$HOME/.rbenv" RBENV_VERSION="2.5.1" RAILS_ENV="production" ; $HOME/.rbenv/bin/rbenv exec bundle exec unicorn -c /var/www/freemarket_sample_53a/current/config/unicorn.rb -E production -D  )

 DEBUG [f1721628] 	master failed to start, check stderr log for details
```

### cat unicorn.stderr.log
```
[2019-11-08T11:40:43.760744 #4532]  INFO -- : Refreshing Gem list
[fog][WARNING] Unable to fetch credentials: Expected(200) <=> Actual(404 Not Found)

bundler: failed to load command: unicorn (/var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/bin/unicorn)
ArgumentError: Missing required arguments: aws_access_key_id, aws_secret_access_key
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/fog-core-2.1.2/lib/fog/core/service.rb:244:in `validate_options'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/fog-core-2.1.2/lib/fog/core/service.rb:268:in `handle_settings'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/fog-core-2.1.2/lib/fog/core/service.rb:98:in `new'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/fog-core-2.1.2/lib/fog/core/services_mixin.rb:16:in `new'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/carrierwave-2.0.1/lib/carrierwave/storage/fog.rb:68:in `eager_load'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/carrierwave-2.0.1/lib/carrierwave.rb:77:in `block in <class:Railtie>'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:51:in `each'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/application/finisher.rb:68:in `block in <module:Finisher>'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/initializable.rb:32:in `instance_exec'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/initializable.rb:32:in `run'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/initializable.rb:61:in `block in run_initializers'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `each'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `call'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:226:in `tsort_each'
  /home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:205:in `tsort_each'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/initializable.rb:60:in `run_initializers'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/railties-5.2.3/lib/rails/application.rb:361:in `initialize!'
  /var/www/freemarket_sample_53a/releases/20191108114021/config/environment.rb:5:in `<top (required)>'
  config.ru:4:in `require_relative'
  config.ru:4:in `block in <main>'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `instance_eval'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `initialize'
  config.ru:1:in `new'
  config.ru:1:in `<main>'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/unicorn-5.4.1/lib/unicorn.rb:56:in `eval'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/unicorn-5.4.1/lib/unicorn.rb:56:in `block in builder'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/unicorn-5.4.1/lib/unicorn/http_server.rb:795:in `build_app!'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/unicorn-5.4.1/lib/unicorn/http_server.rb:139:in `start'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/gems/unicorn-5.4.1/bin/unicorn:126:in `<top (required)>'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/bin/unicorn:23:in `load'
  /var/www/freemarket_sample_53a/shared/bundle/ruby/2.5.0/bin/unicorn:23:in `<top (required)>'
```